### PR TITLE
Add new feature: yarn background scripts [WIP]

### DIFF
--- a/accepted/0000-background-scripts.md
+++ b/accepted/0000-background-scripts.md
@@ -96,7 +96,7 @@ Nice to have:
 
 ## API Design
 
-We will expose a new subcommand, `yarn pg` to allow developers to interact with their background scripts.
+We will expose a new subcommand, `yarn bg` to allow developers to interact with their background scripts.
 
 ### Starting/Stoping/Restarting background scripts
 
@@ -136,7 +136,7 @@ There are a few options:
 
    Notes:
 
-   - Would require developers to add a new line `.gitignore` (prior art: node_modules)
+   - Would require developers to add a new line to `.gitignore` (prior art: .yarnrc)
 
 2. Storing in a `node_modules/.yarn-background-scripts` directory, relative to the current working directory of the repo
 


### PR DESCRIPTION
Here's a stab at a crazy idea: yarn background scripts.

e.g.

```
"backgroundScripts": {
    "express-server": "nodemon lib/index.js",
    "babel-compiler": "yarn build --watch",
    "mock-json-server": "json-server --watch db.json"
}
```

enables:

![example status API](https://i.imgur.com/2a1Mhx1.png)


It's not unlikely that we decide this feature doesn't belong in yarn, but I think there could be some benefits to doing so, as detailed in the RFC.

This is an early stage RFC - at this stage, trying to gauge at a high level if this feature belongs in yarn or not.

Thanks!